### PR TITLE
Bugfix: Add namespace to build.gradle to support gradle 8.x

### DIFF
--- a/Source/pushwoosh/android/build.gradle
+++ b/Source/pushwoosh/android/build.gradle
@@ -22,6 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    namespace 'com.pushwoosh.plugin'
     compileSdkVersion 33
 
     defaultConfig {


### PR DESCRIPTION
Currently when updating our flutter projects to Gradle version 8.x we encountered the following error:

```
* What went wrong:
Failed to query the value of property 'buildFlowServiceProperty'.
> Could not isolate value org.jetbrains.kotlin.gradle.plugin.statistics.BuildFlowService$Parameters_Decorated@16aab65e of type BuildFlowService.Parameters
   > A problem occurred configuring project ':pushwoosh_flutter'.
      > Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
         > Namespace not specified. Specify a namespace in the module's build file. See https://d.android.com/r/tools/upgrade-assistant/set-namespace for information about setting the namespace.

           If you've specified the package attribute in the source AndroidManifest.xml, you can use the AGP Upgrade Assistant to migrate to the namespace value in the build file. Refer to https://d.android.com/r/tools/upgrade-assistant/agp-upgrade-assistant for general information about using the AGP Upgrade Assistant.
```

**Cause:** `build.gradle` is missing the namespace declaration in the android section.
**Solution:** Add namespace `com.pushwoosh.plugin` to `build.gradle`
         